### PR TITLE
Better handling of output

### DIFF
--- a/.github/workflows/build_test_fmt.yml
+++ b/.github/workflows/build_test_fmt.yml
@@ -12,6 +12,17 @@ jobs:
       run: |
           cargo fmt -- --check
 
+  check:
+    runs-on: ubuntu-latest
+    needs: coding-style
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check testsuite-adaptor
+      run: cargo check
+    - name: Run Clippy
+      run: cargo clippy --all
+
   build:
     runs-on: ubuntu-latest
     needs: coding-style

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "ftf"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftf"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["cohenarthur <arthur.cohen@epita.fr>"]
 edition = "2018"
 license-file = "LICENSE.md"

--- a/src/expected.rs
+++ b/src/expected.rs
@@ -6,8 +6,8 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct ExpGot<T: PartialEq> {
-    pub expected: Option<T>,
-    pub got: T,
+    pub(crate) expected: Option<T>,
+    pub(crate) got: T,
 }
 
 impl<T: PartialEq> ExpGot<T> {
@@ -20,6 +20,27 @@ impl<T: PartialEq> ExpGot<T> {
     pub fn eq(&self) -> bool {
         match &self.expected {
             Some(s) => s == &self.got,
+            None => true,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExpString {
+    pub(crate) expected: Option<String>,
+    pub(crate) got: String,
+}
+
+impl ExpString {
+    /// Create a new ExpString
+    pub fn new(expected: Option<String>, got: String) -> ExpString {
+        ExpString { expected, got }
+    }
+
+    /// Check if the expected content are contained in the output
+    pub fn matches(&self) -> bool {
+        match &self.expected {
+            Some(msg) => self.got.contains(msg),
             None => true,
         }
     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use wait_timeout::ChildExt;
 
 use crate::error::Error;
-use crate::exp_got::ExpGot;
+use crate::expected::{ExpGot, ExpString};
 use crate::log;
 use crate::output::Output;
 use crate::INVALID_EXIT;
@@ -96,8 +96,8 @@ impl Launcher {
                 Some(self.exit_code.unwrap_or(0)),
                 status_code.unwrap_or(INVALID_EXIT),
             ),
-            ExpGot::new(self.stdout, out),
-            ExpGot::new(self.stderr, err),
+            ExpString::new(self.stdout, out),
+            ExpString::new(self.stderr, err),
             ExpGot::new(self.timeout, start.elapsed()),
         ))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod error;
-pub mod exp_got;
+pub mod expected;
 pub mod input;
 pub mod launcher;
 mod log;

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,7 +5,7 @@
 use std::time::Duration;
 
 use crate::error::Error;
-use crate::exp_got::ExpGot;
+use crate::expected::{ExpGot, ExpString};
 use crate::log;
 
 use serde::Serialize;
@@ -16,8 +16,8 @@ use serde::Serialize;
 pub struct Output {
     name: String,
     exit_code: ExpGot<i32>,
-    stdout: ExpGot<String>,
-    stderr: ExpGot<String>,
+    stdout: ExpString,
+    stderr: ExpString,
     time: ExpGot<Duration>,
 }
 
@@ -26,8 +26,8 @@ impl Output {
     pub fn new(
         name: String,
         exit_code: ExpGot<i32>,
-        stdout: ExpGot<String>,
-        stderr: ExpGot<String>,
+        stdout: ExpString,
+        stderr: ExpString,
         time: ExpGot<Duration>,
     ) -> Output {
         let out = Output {
@@ -48,7 +48,7 @@ impl Output {
     }
 
     pub fn is_valid(&self) -> bool {
-        self.exit_code().eq() && self.stdout.eq() && self.stderr.eq() && self.time.eq()
+        self.exit_code().eq() && self.stdout.matches() && self.stderr.matches() && self.time.eq()
     }
 
     /// Display the output of a command accordingly, with the following format:

--- a/tests/ft_for_ft.yml
+++ b/tests/ft_for_ft.yml
@@ -22,3 +22,9 @@ tests:
       args:
         - "3"
       exit_code: 0
+
+    - name: "stdout is contains() and not eq()"
+      binary: "echo"
+      args:
+        - "some long string"
+      stdout: "long"


### PR DESCRIPTION
This PR makes strings given in the `stdout` or `stderr` matched as "substrings" of the received output instead of strict equality. This is useful when you'd like to make sure that a test produces a certain type of error, but don't care about the exact content (or in the case that that content might be unstable).

Since this is a behavioral change, we should also bump the version number